### PR TITLE
refactor: improve error handling in getProductById function

### DIFF
--- a/src/services/product.service.ts
+++ b/src/services/product.service.ts
@@ -3,19 +3,29 @@ import { Category } from "@/models/category.model";
 import { isApiError } from "@/models/error.model";
 import { Product } from "@/models/product.model";
 
-import { products } from "../fixtures/products.fixture";
+export async function getProductsByCategorySlug(categorySlug: Category["slug"]): Promise<Product[]> {
+  try {
+    const res_category = await fetch(`${API_URL}/categories/${categorySlug}`);
+    const category = await res_category.json();
 
-export function getProductsByCategorySlug(
-  categorySlug: Category["slug"]
-): Promise<Product[]> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const filteredProducts = products.filter(
-        (product) => product.categorySlug === categorySlug
-      );
-      resolve(filteredProducts);
-    }, 500);
-  });
+    if (!res_category.ok) {
+      if (isApiError(category)) throw new Error(category.error.message);
+      throw new Error("Unknown error");
+    }
+
+    const res_products = await fetch(`${API_URL}/products?categoryId=${category.id}`);
+    const products = await res_products.json();
+
+    if (!res_products.ok) {
+      if (isApiError(products)) throw new Error(products.error.message);
+      throw new Error("Unknown error");
+    }
+
+    return products as Product[];
+  } catch (error) {
+    console.error(error);
+    throw error;
+  }
 }
 
 export async function getProductById(id: number): Promise<Product> {


### PR DESCRIPTION
Se refactorizo el manejo de errores consumiendo **_isApiError_** como modelo de errores en la funcion de **_getProductById()_** en _**product.service.ts**_