### PR TITLE
Migración de product de module.css a Tailwind

### DIFF
--- a/src/routes/product/index.tsx
+++ b/src/routes/product/index.tsx
@@ -53,7 +53,7 @@ export default function Product() {
             </Button>
             <Separator className="my-6" /> 
             <div>
-              <h2 className="text-[0.875rem] leading-5 font-semibold text-accent-foreground mb-6"> 
+              <h2 className="text-sm font-semibold text-accent-foreground mb-6"> 
                 Características
               </h2>
               <ul className="list-disc pl-4 text-sm leading-5 text-muted-foreground"> 


### PR DESCRIPTION
 Migración de `product` de module.css a Tailwind  
- Se eliminaron las clases de CSS Modules y se reemplazaron por utilidades de Tailwind.  
- Ahora el estilo es más eficiente y fácil de mantener.  
Closes #51 