### PR TITLE
Refactorización del Componente Label con Class Variance Authority

### DIFF
--- a/src/components/ui/label/index.tsx
+++ b/src/components/ui/label/index.tsx
@@ -1,20 +1,45 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-import styles from "./styles.module.css";
+const labelVariants = cva("text-sm font-medium leading-none", {
+  variants: {
+    variant: {
+      default: "text-foreground",
+      error: "text-destructive",
+      muted: "text-muted-foreground",
+      disabled: "cursor-not-allowed opacity-70",
+    },
+    size: {
+      default: "text-sm",
+      xs: "text-xs",
+      sm: "text-sm",
+      base: "text-base",
+      lg: "text-lg",
+    },
+  },
+  defaultVariants: {
+    variant: "default",
+    size: "default",
+  },
+});
 
-const Label = React.forwardRef<
-  React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => (
+interface LabelProps
+  extends React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {
+  asChild?: boolean;
+}
+
+const Label = React.forwardRef<React.ElementRef<typeof LabelPrimitive.Root>,LabelProps>(
+  ({ className, variant, size, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}
-    className={cn(styles.label, className)}
+    className={cn(labelVariants({ variant, size, className }))}
     {...props}
   />
 ));
 Label.displayName = LabelPrimitive.Root.displayName;
 
-export { Label };
+export { Label, type LabelProps, labelVariants };


### PR DESCRIPTION
Este PR introduce cambios en el componente Label para mejorar su mantenibilidad y flexibilidad de estilos, this PR closes #70.

Cambios Realizados:

- Implementación de class-variance-authority (cva) para estilos dinámicos
- Agregadas variantes con estilos predefinidos:
            [default](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Estilo estándar de etiqueta
            [error](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Para estados de error usando colores destructivos
            [muted](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Para etiquetas menos prominentes
            [disabled](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Para estado deshabilitado con opacidad reducida
            Introducidas variantes de tamaño:
            [xs](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Texto extra pequeño
            [sm](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Texto pequeño
            [base](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Tamaño base de texto
            [lg](vscode-file://vscode-app/c:/Users/Mike/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html): Texto grande
- Se mantiene la integración con Radix UI con soporte TypeScript adecuado
- Uso de clases Tailwind para un estilo consistente

