### PR TITLE
feat(section): implement variant props for dynamic padding in Section component

### DIFF
--- a/src/components/ui/section/index.tsx
+++ b/src/components/ui/section/index.tsx
@@ -1,17 +1,42 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import { HTMLAttributes } from "react";
 
 import { cn } from "@/lib/utils";
 
-import styles from "./styles.module.css";
+const sectionVariants = cva("", {
+  variants: {
+    padding: {
+      default: "py-12 md:py-16",
+      none: "py-0",
+      sm: "py-6 md:py-8",
+      lg: "py-16 md:py-20",
+    },
+  },
+  defaultVariants: {
+    padding: "default",
+  },
+});
 
-interface SectionProps extends HTMLAttributes<HTMLElement> {
+interface SectionProps
+  extends HTMLAttributes<HTMLElement>,
+    VariantProps<typeof sectionVariants> {
   children: React.ReactNode;
 }
 
-export function Section({ className, children, ...props }: SectionProps) {
+export function Section({ 
+  className, 
+  children, 
+  padding,
+  ...props 
+}: SectionProps) {
   return (
-    <section className={cn(styles.section, className)} {...props}>
+    <section 
+      className={cn(sectionVariants({ padding, className }))} 
+      {...props}
+    >
       {children}
     </section>
   );
 }
+
+export { type SectionProps, sectionVariants };


### PR DESCRIPTION
Se hizo la migración del componente "section" a Tailwind CSS

- Utilizamos class-variance-authority (cva) para manejar las variantes
- Definimos 4 variantes de padding (default, none, sm, lg)
- Mantuvimos el diseño responsive usando clases de Tailwind

Ejemplos de como poder consumirlo desde algún otro componente:
```
<Section>Default padding</Section>
<Section padding="none">No padding</Section>
<Section padding="sm">Small padding</Section>
<Section padding="lg">Large padding</Section>
```