### PR TITLE
Refactor not-found route definition

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -42,10 +42,7 @@ export default [
           },
         ],
       },
-      {
-        path: "/not-found",
-        file: "./routes/not-found/index.tsx",
-      },
+      route("/not-found", "./routes/not-found/index.tsx"),
     ],
   },
 ] satisfies RouteConfig;


### PR DESCRIPTION
Change the definition of the not-found path to use the route function for consistency with other routes.