### PR TITLE
feat(e2e/order): add test for guest checkout flow and reusable order form helpers

### DIFF
--- a/src/e2e/guest-create-order.spec.ts
+++ b/src/e2e/guest-create-order.spec.ts
@@ -1,0 +1,36 @@
+// import { createOrderFormData } from "@/lib/utils.tests";
+import { expect, test } from "@playwright/test";
+import { createOrderFormData } from "./utils-tests-e2e";
+
+export type OrderFormData = Record<string, string>;
+
+test.describe("Guest", () => {
+  test("Guest can create an order", async ({ page }) => {
+    // Navegar a la tienda y agregar un producto
+    await page.goto("http://localhost:5173/");
+
+    await page.getByRole("menuitem", { name: "Polos" }).click();
+    await page.getByTestId("product-item").first().click();
+
+    await page.getByRole("button", { name: "Agregar al Carrito" }).click();
+    await page.getByRole("link", { name: "Carrito de compras" }).click();
+
+    await page.getByRole("link", { name: "Continuar Compra" }).click();
+
+    // Llenar correctamente los campos
+    const orderForm = createOrderFormData();
+    for (const [key, value] of Object.entries(orderForm)) {
+      const input = await page.getByRole("textbox", { name: key });
+      await input.click();
+      await input.fill(value);
+    }
+    await page.getByRole("combobox", { name: "País" }).selectOption("PE");
+
+    await page.getByRole("button", { name: "Confirmar Orden" }).click();
+
+    await expect(
+      page.getByText("¡Muchas gracias por tu compra!")
+    ).toBeVisible();
+    await expect(page.getByTestId("orderId")).toBeVisible();
+  });
+});

--- a/src/e2e/utils-tests-e2e.ts
+++ b/src/e2e/utils-tests-e2e.ts
@@ -1,0 +1,18 @@
+/* Helper functions → Playwright */
+
+export type OrderFormData = Record<string, string>;
+
+export const createOrderFormData = (
+  overrides?: Partial<OrderFormData>
+): OrderFormData => ({
+  "Correo electrónico": "testinodp@codeable.com",
+  Nombre: "Testino",
+  Apellido: "Diprueba",
+  Compañia: "",
+  Dirección: "Calle Di Prueba 123",
+  Ciudad: "Lima",
+  "Provincia/Estado": "Lima",
+  "Código Postal": "51111",
+  Teléfono: "987456321",
+  ...overrides,
+});


### PR DESCRIPTION
Closes #191
- End-to-end test with Playwright where a guest can create and complete an order
- Reusable helper to generate order form data with override support