### PR TITLE
feat: add variants attributes and values tables, remove price from products

### DIFF
--- a/prisma/migrations/20250820183901_add_tables_variants_products/migration.sql
+++ b/prisma/migrations/20250820183901_add_tables_variants_products/migration.sql
@@ -1,0 +1,43 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `price` on the `products` table. All the data in the column will be lost.
+
+*/
+-- AlterTable
+ALTER TABLE "products" DROP COLUMN "price";
+
+-- CreateTable
+CREATE TABLE "variants_attributes" (
+    "id" SERIAL NOT NULL,
+    "name" TEXT NOT NULL,
+    "created_at" TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "variants_attributes_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "variants_attributes_values" (
+    "id" SERIAL NOT NULL,
+    "attribute_id" INTEGER NOT NULL,
+    "product_id" INTEGER NOT NULL,
+    "value" TEXT NOT NULL,
+    "price" DECIMAL(10,2) NOT NULL,
+    "created_at" TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(0) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "variants_attributes_values_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "variants_attributes_name_key" ON "variants_attributes"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "variants_attributes_values_attribute_id_product_id_value_key" ON "variants_attributes_values"("attribute_id", "product_id", "value");
+
+-- AddForeignKey
+ALTER TABLE "variants_attributes_values" ADD CONSTRAINT "variants_attributes_values_attribute_id_fkey" FOREIGN KEY ("attribute_id") REFERENCES "variants_attributes"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "variants_attributes_values" ADD CONSTRAINT "variants_attributes_values_product_id_fkey" FOREIGN KEY ("product_id") REFERENCES "products"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,7 +55,6 @@ model Product {
   title       String
   imgSrc      String   @map("img_src")
   alt         String?
-  price       Decimal  @db.Decimal(10, 2)
   description String?
   categoryId  Int?     @map("category_id")
   isOnSale    Boolean  @default(false) @map("is_on_sale")
@@ -63,11 +62,39 @@ model Product {
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamp(0)
   updatedAt   DateTime @default(now()) @map("updated_at") @db.Timestamp(0)
 
-  category   Category?   @relation(fields: [categoryId], references: [id], onDelete: SetNull)
-  cartItems  CartItem[]
-  orderItems OrderItem[]
+  category               Category?                @relation(fields: [categoryId], references: [id], onDelete: SetNull)
+  cartItems              CartItem[]
+  orderItems             OrderItem[]
+  VariantsAttributeValue VariantsAttributeValue[]
 
   @@map("products")
+}
+
+model VariantsAttribute {
+  id        Int      @id @default(autoincrement())
+  name      String   @unique
+  createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(0)
+  updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamp(0)
+
+  variantsAttributeValue VariantsAttributeValue[]
+
+  @@map("variants_attributes")
+}
+
+model VariantsAttributeValue {
+  id          Int      @id @default(autoincrement())
+  attributeId Int      @map("attribute_id")
+  productId   Int      @map("product_id")
+  value       String
+  price       Decimal  @db.Decimal(10, 2)
+  createdAt   DateTime @default(now()) @map("created_at") @db.Timestamp(0)
+  updatedAt   DateTime @default(now()) @map("updated_at") @db.Timestamp(0)
+
+  variantAttribute VariantsAttribute @relation(fields: [attributeId], references: [id])
+  product          Product           @relation(fields: [productId], references: [id])
+
+  @@unique([attributeId, productId, value], name: "unique_attribute_product_value")
+  @@map("variants_attributes_values")
 }
 
 model Cart {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -70,18 +70,18 @@ model Product {
   @@map("products")
 }
 
-model VariantsAttribute {
+model VariantAttribute {
   id        Int      @id @default(autoincrement())
   name      String   @unique
   createdAt DateTime @default(now()) @map("created_at") @db.Timestamp(0)
   updatedAt DateTime @default(now()) @map("updated_at") @db.Timestamp(0)
 
-  variantsAttributeValue VariantsAttributeValue[]
+  variantsAttributeValue VariantAttributeValue[]
 
   @@map("variants_attributes")
 }
 
-model VariantsAttributeValue {
+model VariantAttributeValue {
   id          Int      @id @default(autoincrement())
   attributeId Int      @map("attribute_id")
   productId   Int      @map("product_id")
@@ -90,7 +90,7 @@ model VariantsAttributeValue {
   createdAt   DateTime @default(now()) @map("created_at") @db.Timestamp(0)
   updatedAt   DateTime @default(now()) @map("updated_at") @db.Timestamp(0)
 
-  variantAttribute VariantsAttribute @relation(fields: [attributeId], references: [id])
+  variantAttribute VariantAttribute @relation(fields: [attributeId], references: [id])
   product          Product           @relation(fields: [productId], references: [id])
 
   @@unique([attributeId, productId, value], name: "unique_attribute_product_value")

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -65,7 +65,7 @@ model Product {
   category               Category?                @relation(fields: [categoryId], references: [id], onDelete: SetNull)
   cartItems              CartItem[]
   orderItems             OrderItem[]
-  VariantsAttributeValue VariantsAttributeValue[]
+  variantAttributeValues VariantAttributeValue[]
 
   @@map("products")
 }


### PR DESCRIPTION
Se modifico el schema.prisma con las nuevas tablas, y también se elimino el "price" de la tabla products:

<img width="957" height="634" alt="image" src="https://github.com/user-attachments/assets/6293cd36-1605-462d-8c21-2c148586ec0b" />

La logica de datos seria algo similar a:
<img width="873" height="270" alt="image" src="https://github.com/user-attachments/assets/f46c1f42-ecb3-4f1d-bd30-5e95e9e65b0a" />

<img width="912" height="420" alt="image" src="https://github.com/user-attachments/assets/9e13ada8-3ba0-4608-a43a-cbc94e7fa92f" />

<img width="886" height="593" alt="image" src="https://github.com/user-attachments/assets/d6180656-ea13-470d-91ed-81eedac5883c" />

@JanetHugarcia ya puedes guiarte de los nombres de columnas para corregir el initita_data.ts

@JanetHugarcia @Vazzukoff recuerden que hasta este punto si corren la app, les dará un error (por la eliminación del price de la tabla products), el cual será corregido en el FRONT en los próximos issues:
<img width="762" height="756" alt="image" src="https://github.com/user-attachments/assets/724f1c47-da22-4d34-ae24-b0148223dca5" />
